### PR TITLE
Interpret ObjectDisposedException as not connected socket state

### DIFF
--- a/Vostok.ClusterClient.Transport.Webrequest/ConnectTimeoutHelper.cs
+++ b/Vostok.ClusterClient.Transport.Webrequest/ConnectTimeoutHelper.cs
@@ -27,6 +27,10 @@ namespace Vostok.Clusterclient.Transport.Webrequest
             {
                 return isSocketConnected(request);
             }
+            catch (ObjectDisposedException)
+            {
+                return false;
+            }
             catch (Exception error)
             {
                 canCheckSocket = false;


### PR DESCRIPTION
Handle ObjectDisposedException in ConnectTimeoutHelper as disconnected socket

In random cases ConnectTimeoutHelper can stop working leading to 21 second connection timeouts instead of user defined.

Closes #3